### PR TITLE
Fix for issue ticket #33 completing order by adding payment type

### DIFF
--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -127,7 +127,7 @@ class Orders(ViewSet):
         """
         customer = Customer.objects.get(user=request.auth.user)
         order = Order.objects.get(pk=pk, customer=customer)
-        payment = Payment.objects.get(pk=request.data["payment_type"])
+        payment = Payment.objects.get(pk=request.data["paymentTypeId"])
         order.payment_type = payment
         order.save()
 

--- a/tests/order.py
+++ b/tests/order.py
@@ -119,7 +119,7 @@ class OrderTests(APITestCase):
         payment_id = json_response["id"]
 
         url = f"/orders/{order_id}"
-        data = {"payment_type": payment_id}
+        data = {"paymentTypeId": payment_id}
         self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
         response = self.client.put(url, data, format="json")
 


### PR DESCRIPTION
## Changes

-Changed naming conventions in the update method on `Orders` class to reflect what the client was sending in request body
-Changed the same name in the test for this method to reflect new name

## Requests / Responses

**Request**

PUT /orders/{order.id} updates order with payment type for completion.

```json
{
    "paymentTypeId": 1
}
```

**Response**

HTTP/1.1 204 NO CONTENT

## Testing

- [ ] Run migrations
- [ ] Run test suite


## Related Issues

- Fixes #33 