### PR TITLE
fix for delete request to remove order product by lineitem id

### DIFF
--- a/bangazon/urls.py
+++ b/bangazon/urls.py
@@ -10,7 +10,7 @@ from bangazonapi.views import *
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r"products", Products, "product")
 router.register(r"productcategories", ProductCategories, "productcategory")
-router.register(r"lineitems", LineItems, "orderproduct")
+router.register(r"lineitem", LineItems, "orderproduct")
 router.register(r"customers", Customers, "customer")
 router.register(r"users", Users, "user")
 router.register(r"orders", Orders, "order")

--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -1,5 +1,5 @@
-
 """View module for handling requests about line items"""
+
 from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
@@ -9,14 +9,15 @@ from bangazonapi.models import OrderProduct, Order, Product, Customer
 
 
 class LineItemSerializer(serializers.HyperlinkedModelSerializer):
-    """JSON serializer for line items """
+    """JSON serializer for line items"""
+
     class Meta:
         model = OrderProduct
         url = serializers.HyperlinkedIdentityField(
-            view_name='lineitem',
-            lookup_field='id'
+            view_name="lineitem", lookup_field="id"
         )
-        fields = ('id', 'url', 'order', 'product')
+        fields = ("id", "url", "order", "product")
+
 
 class LineItems(ViewSet):
     """Line items for Bangazon orders"""
@@ -53,16 +54,16 @@ class LineItems(ViewSet):
             customer = Customer.objects.get(user=request.auth.user)
             line_item = OrderProduct.objects.get(pk=pk, order__customer=customer)
 
-            serializer = LineItemSerializer(line_item, context={'request': request})
+            serializer = LineItemSerializer(line_item, context={"request": request})
 
             return Response(serializer.data)
 
         except OrderProduct.DoesNotExist as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
     def destroy(self, request, pk=None):
         """
-        @api {DELETE} /cart/:id DELETE line item from cart
+        @api {DELETE} /lineitem/:id DELETE line item from cart
         @apiName RemoveLineItem
         @apiGroup ShoppingCart
 
@@ -77,11 +78,13 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
-
-            return Response({}, status=status.HTTP_204_NO_CONTENT)
+            order_product.delete()
+            return Response(status=status.HTTP_204_NO_CONTENT)
 
         except OrderProduct.DoesNotExist as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
 
         except Exception as ex:
-            return Response({'message': ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+            return Response(
+                {"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )


### PR DESCRIPTION
These changes allow the API to properly support the deletion of an item from the user's cart

## Changes

- Url endpoint changed to lineitem
- Added **order_product.delete()** in destroy method of the lineitems class

## Requests / Responses


**Request**

DELETE `/lineitem/n` removes row "n" from `orderproduct` table


**Response**

HTTP/1.1 204 NO CONTENT


## Testing

1. Be logged in as authenticated user
2. Add a product to the cart
3. Navigate to the cart view
4. Click the trash can icon _(delete button)_
5. The client will re-render the cart details without the deleted item
6. Trust, but verify:  view the network dev panel and see the successful delete request to the api, and view the database table to ensure that the correct item was deleted.


## Related Issues

- Fixes bug ticket #8 