### PR TITLE
Favorite Stores

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,7 @@
         "--django-settings-module=bangazon.settings",
         "--max-line-length=120"
     ],
+    "cSpell.words": [
+        "favoritesellers"
+    ],
 }

--- a/bangazonapi/fixtures/favoritesellers.json
+++ b/bangazonapi/fixtures/favoritesellers.json
@@ -14,13 +14,5 @@
             "customer_id": 7,
             "seller_id": 6
         }
-    },
-    {
-        "pk": 3,
-        "model": "bangazonapi.favorite",
-        "fields": {
-            "customer_id": 7,
-            "seller_id": 7
-        }
     }
 ]

--- a/bangazonapi/models/customer.py
+++ b/bangazonapi/models/customer.py
@@ -4,7 +4,10 @@ from django.contrib.auth.models import User
 
 class Customer(models.Model):
 
-    user = models.OneToOneField(User, on_delete=models.DO_NOTHING,)
+    user = models.OneToOneField(
+        User,
+        on_delete=models.DO_NOTHING,
+    )
     phone_number = models.CharField(max_length=15)
     address = models.CharField(max_length=55)
 
@@ -17,9 +20,17 @@ class Customer(models.Model):
         self.__recommends = value
 
     @property
+    def favorites(self):
+        return self.__favorites
+
+    @favorites.setter
+    def favorites(self, value):
+        self.__favorites = value
+
+    @property
     def store(self):
         return self.__store
-    
+
     @store.setter
     def store(self, value):
         self.__store = value

--- a/bangazonapi/models/favorite.py
+++ b/bangazonapi/models/favorite.py
@@ -6,7 +6,21 @@ from .orderproduct import OrderProduct
 from safedelete.models import SafeDeleteModel
 from safedelete.models import SOFT_DELETE
 
+
 class Favorite(models.Model):
 
-    customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING,)
-    seller = models.ForeignKey(Customer, on_delete=models.DO_NOTHING, related_name='favorited_seller')
+    customer = models.ForeignKey(
+        Customer,
+        on_delete=models.DO_NOTHING,
+    )
+    seller = models.ForeignKey(
+        Customer, on_delete=models.DO_NOTHING, related_name="favorited_seller"
+    )
+
+    @property
+    def store(self):
+        return self.__store
+
+    @store.setter
+    def store(self, value):
+        self.__store = value

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -191,19 +191,23 @@ class Profile(ViewSet):
             try:
                 open_order = Order.objects.get(customer=current_user, payment_type=None)
                 line_items = OrderProduct.objects.filter(order=open_order)
-                
-                
-                serialized_line_items = LineItemSerializer(line_items, many=True, context={"request": request})
+
+                serialized_line_items = LineItemSerializer(
+                    line_items, many=True, context={"request": request}
+                )
 
                 cart = {}
-                cart["order"] = OrderSerializer(open_order, many=False, context={"request": request}).data
+                cart["order"] = OrderSerializer(
+                    open_order, many=False, context={"request": request}
+                ).data
 
-                
-                cart["order"]["lineitems"] = serialized_line_items.data  
+                cart["order"]["lineitems"] = serialized_line_items.data
                 cart["order"]["size"] = len(serialized_line_items.data)
 
             except Order.DoesNotExist as ex:
-                return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+                return Response(
+                    {"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND
+                )
 
             return Response(cart["order"])
 
@@ -271,7 +275,7 @@ class Profile(ViewSet):
         return Response({}, status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
     @action(methods=["get", "post", "delete"], detail=False)
-    def favoritesellers(self, request):
+    def favoritesellers(self, request, pk=None):
         """
         @api {GET} /profile/favoritesellers GET favorite sellers
         @apiName GetFavoriteSellers
@@ -339,9 +343,12 @@ class Profile(ViewSet):
             return Response(status=status.HTTP_201_CREATED)
 
         if request.method == "DELETE":
+            customer = Customer.objects.get(user=request.auth.user)
             store = Store.objects.get(pk=request.data["store_id"])
             seller = Customer.objects.get(pk=store.seller_id)
-            favorite_to_delete = Favorite.objects.get(seller=seller)
+            favorite_to_delete = Favorite.objects.get(
+                seller_id=seller, customer_id=customer.id
+            )
             favorite_to_delete.delete()
             return Response(status=status.HTTP_204_NO_CONTENT)
 

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -1,7 +1,7 @@
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers, status
-from bangazonapi.models import Store, Product, Customer
+from bangazonapi.models import Store, Product, Customer, Favorite
 
 
 class StoreSellerSerializer(serializers.ModelSerializer):
@@ -61,9 +61,15 @@ class StoreViewSet(ViewSet):
     def retrieve(self, request, pk=None):
         """GET a single store by ID"""
         try:
+            current_customer = Customer.objects.get(user=request.auth.user)
             store = Store.objects.get(pk=pk)
             serializer = StoreSerializer(store)
-            return Response(serializer.data, status=status.HTTP_200_OK)
+            is_favorite = Favorite.objects.filter(
+                customer=current_customer, seller=store.seller
+            ).exists()
+            store_data = serializer.data
+            store_data["is_favorite"] = is_favorite
+            return Response(store_data, status=status.HTTP_200_OK)
         except Store.DoesNotExist:
             return Response(
                 {"message": "Store not found."}, status=status.HTTP_404_NOT_FOUND

--- a/bangazonapi/views/store.py
+++ b/bangazonapi/views/store.py
@@ -54,8 +54,6 @@ class StoreViewSet(ViewSet):
         )
 
         serializer = StoreSerializer(new_store)
-        print("Store Created with ID:", new_store.id)  # Debugging log for backend
-        print("Serialized data:", serializer.data)  # Add this log for debugging
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     def retrieve(self, request, pk=None):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,4 @@
 from .product import ProductTests
 from .order import OrderTests
 from .payments import PaymentTests
+from .store import StoreTests

--- a/tests/store.py
+++ b/tests/store.py
@@ -1,0 +1,24 @@
+import json
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+
+class OrderTests(APITestCase):
+    def setUp(self) -> None:
+        """
+        Create a new account and create sample category
+        """
+        url = "/register"
+        data = {
+            "username": "steve",
+            "password": "Admin8*",
+            "email": "steve@stevebrownlee.com",
+            "address": "100 Infinity Way",
+            "phone_number": "555-1212",
+            "first_name": "Steve",
+            "last_name": "Brownlee",
+        }
+        response = self.client.post(url, data, format="json")
+        json_response = json.loads(response.content)
+        self.token = json_response["token"]
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/tests/store.py
+++ b/tests/store.py
@@ -3,7 +3,8 @@ from rest_framework import status
 from rest_framework.test import APITestCase
 
 
-class OrderTests(APITestCase):
+
+class StoreTests(APITestCase):
     def setUp(self) -> None:
         """
         Create a new account and create sample category
@@ -21,4 +22,37 @@ class OrderTests(APITestCase):
         response = self.client.post(url, data, format="json")
         json_response = json.loads(response.content)
         self.token = json_response["token"]
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_create_a_store(self):
+        """
+        Create a store by sending POST to /stores
+        """
+        url = "/stores"
+        data = {"name": "Test Store", "description": "Description of Test Store"}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
+        json_response = json.loads(response.content)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(json_response["name"], "Test Store")
+        self.assertEqual(json_response["description"], "Description of Test Store")
+
+    def test_favorite_a_store(self):
+        """
+        Favorite a store by sending a POST to /profile/favoritesellers
+        """
+
+        url = "/stores"
+        data = {"name": "Test Store", "description": "Description of Test Store"}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
+        json_response = json.loads(response.content)
+        store_id = json_response["id"]
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        url = "/profile/favoritesellers"
+        data = {"store_id": store_id}
+        self.client.credentials(HTTP_AUTHORIZATION="Token " + self.token)
+        response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)


### PR DESCRIPTION
Allows users to favorite/unfavorite stores

## Changes

- Removed fixture for Brenda favoriting her own store
- Added favorites property and setter to `Customer` model
- Added store property and setter to `Favorite` model
- Added favorites getter to profile list function
- Removed print statement in `profile/cart` list function
- Added `POST` and `DELETE` functionality to `profile/favoritesellers`
- Moved `ProfileSerializer` to the bottom of the module so It can see the other serializes it is dependent on
- Changes made to `ProfileSerializer` and `FavoriteUserSerializer` to incorporate all necessary data
- Removed print statements in `StoreSellerSerializer`
- Added to Store retrieve function to ad an `is_favorite` property when returning store details
- Added Store.py module to test suite including two new tests that verify store creation and the ability to favorite a store

## Requests / Responses

**Request**

POST `/profile/favoritesellers` favorites a store
DELETE `/profile/favoritesellers` unfavorites a store

```json
{
    "store_id": StoreId //integer
}
```

**Response**

POST:  201 CREATED

DELETE: 204 NO_CONTENT



## Testing

Description of how to test code...

1. Run Migrations
2. Seed Database
3. Run test suite



## Related Issues

- Implementation of #16 